### PR TITLE
Bibput

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Post, Put and Delete functions will be gradually added in future releases.
 
 | API | Get | Post | Put | Delete |
 | --- | :---: | :---: | :---: | :---: |
-| [bibs](#access-bibliographic-data) | X | | | |
+| [bibs](#access-bibliographic-data) | X |  | X | |
 | [analytics](#access-reports) | X | NA | NA | NA |
 | [acquisitions](#access-acquisitions) | X | | | |
 | [configuration](#access-configuration-settings) | X | | | |
@@ -54,6 +54,25 @@ alma.bibs.representations.get(harry_potter)
 
 # get linked data
 alma.bibs.linked_data.get(harry_potter)
+```
+
+### Update Bibliographic Data
+```python
+# update bibliogrpahic record
+mms_id = "9980963346303126"
+bib_record = alma.bibs.catalog.get(mms_id)
+alma.bibs.catalog.put(mms_id, bib_record, raw=True)
+
+# update holdings record
+holding_id = '22451851260002401'
+holding_record = alma.bibs.catalog.get_holdings(mms_id, holding_id)
+alma.bibs.catalog.put_holdings(mms_id, holding_id, holding_record, raw=True)
+
+# update item record
+item_id = '23144944750002401'
+item_record = alma.bibs.catalog.get_holding_items(mms_id, holding_id, item_id)
+alma.bibs.catalog.put_item(mms_id, holding_id, item_id, item_record, raw=True)
+
 ```
 
 ### Access Reports

--- a/almapipy/bibs.py
+++ b/almapipy/bibs.py
@@ -257,7 +257,7 @@ class SubClientBibsCatalog(Client):
 
         return response
 
-    def put(self, bib_id, body=None, normalization=None, validate=False, q_params={}, raw=True):
+    def put(self, bib_id, body=None, normalization=None, validate=False, q_params={}, raw=False):
         """Update a Bib record
 
         Args:

--- a/almapipy/bibs.py
+++ b/almapipy/bibs.py
@@ -257,6 +257,101 @@ class SubClientBibsCatalog(Client):
 
         return response
 
+    def put(self, bib_id, body=None, normalization=None, validate=False, q_params={}, raw=True):
+        """Update a Bib record
+
+        Args:
+            data (xml/str): This method takes a Bib object.
+                For an IZ record that is linked to NZ record, local fields will be replaced - based on $$9local field indication.
+                Updating of non-local fields should be done directly on the NZ record
+                Note: JSON is not supported for this API.
+            bib_id (str): The bib ID (mms_id).
+            normalization (str): The id of the normalization profile to run.
+            validate (bool): Boolean flag for indicating whether to validate the record.
+            q_params (dict): Any additional query parameters.
+            raw (bool): If true, returns raw requests object.
+
+        Returns:
+            Bib object created.
+
+        """
+        url = self.cnxn_params['api_uri_full']
+        object_type = 'bib'
+        url += ('/' + str(bib_id))
+
+        args = q_params.copy()
+        args['apikey'] = self.cnxn_params['api_key']
+        args['format'] = 'xml'
+
+        if normalization:
+            args['normalization'] = normalization
+        if validate:
+            args['validate'] = validate
+
+        response = self.update(url, body, args, object_type, raw=raw)
+
+        return response
+
+    def put_holdings(self, bib_id, holding_id, body, q_params={}, raw=True):
+        """Update a Holding record
+
+        Args:
+            data (xml/str): This method takes a Holding object.
+                Note: JSON is not supported for this API.
+            bib_id (str): The bib ID (mms_id).
+            holding_id (str): The Holding Record ID (holding_id).
+            q_params (dict): Any additional query parameters.
+            raw (bool): If true, returns raw requests object.
+
+        Returns:
+            Holding object created.
+
+        """
+        url = self.cnxn_params['api_uri_full']
+        url += ('/' + str(bib_id))
+        url += '/holdings'
+        if holding_id:
+            url += ('/' + str(holding_id))
+        object_type = 'holding'
+
+        args = q_params.copy()
+        args['apikey'] = self.cnxn_params['api_key']
+        args['format'] = 'xml'
+
+        response = self.update(url, body, args, object_type, raw=raw)
+
+        return response
+
+    def put_item(self, bib_id, holding_id, item_id, body, q_params={}, raw=True):
+        """Update an Item record
+
+        Args:
+            data (xml/str): This method takes a Item object.
+                Note: JSON is not supported for this API.
+            bib_id (str): The bib ID (mms_id).
+            holding_id (str): The Holding Record ID (holding_id).
+            item_id (str): The Item Record id (item_pid).
+            q_params (dict): Any additional query parameters.
+            raw (bool): If true, returns raw requests object.
+
+        Returns:
+            Item object created.
+
+        """
+        url = self.cnxn_params['api_uri_full']
+        url += ('/' + str(bib_id))
+        url += ('/holdings/' + str(holding_id)) + '/items'
+        if item_id:
+            url += ('/' + str(item_id))
+        object_type = 'item'
+
+        args = q_params.copy()
+        args['apikey'] = self.cnxn_params['api_key']
+        args['format'] = 'xml'
+
+        response = self.update(url, body, args, object_type, raw=raw)
+
+        return response
 
 class SubClientBibsCollections(Client):
     """Handles collections"""

--- a/almapipy/bibs.py
+++ b/almapipy/bibs.py
@@ -257,11 +257,11 @@ class SubClientBibsCatalog(Client):
 
         return response
 
-    def put(self, bib_id, body=None, normalization=None, validate=False, q_params={}, raw=False):
+    def put(self, bib_id, body, normalization=None, validate=False, q_params={}, raw=False):
         """Update a Bib record
 
         Args:
-            data (xml/str): This method takes a Bib object.
+            body (xml/str): This method takes a Bib object.
                 For an IZ record that is linked to NZ record, local fields will be replaced - based on $$9local field indication.
                 Updating of non-local fields should be done directly on the NZ record
                 Note: JSON is not supported for this API.
@@ -272,11 +272,10 @@ class SubClientBibsCatalog(Client):
             raw (bool): If true, returns raw requests object.
 
         Returns:
-            Bib object created.
+            Bib object updated.
 
         """
         url = self.cnxn_params['api_uri_full']
-        object_type = 'bib'
         url += ('/' + str(bib_id))
 
         args = q_params.copy()
@@ -288,8 +287,8 @@ class SubClientBibsCatalog(Client):
         if validate:
             args['validate'] = validate
 
-        cleanxml = self.clean_xml(body)
-        response = self.update(url, cleanxml, args, object_type, raw=raw)
+        cleanxml = utils.Formatter.clean_xml(body)
+        response = self.update(url, cleanxml, args, raw=raw)
 
         return response
 
@@ -297,7 +296,7 @@ class SubClientBibsCatalog(Client):
         """Update a Holding record
 
         Args:
-            data (xml/str): This method takes a Holding object.
+            body (xml/str): This method takes a Holding object.
                 Note: JSON is not supported for this API.
             bib_id (str): The bib ID (mms_id).
             holding_id (str): The Holding Record ID (holding_id).
@@ -305,7 +304,7 @@ class SubClientBibsCatalog(Client):
             raw (bool): If true, returns raw requests object.
 
         Returns:
-            Holding object created.
+            Holding object updated.
 
         """
         url = self.cnxn_params['api_uri_full']
@@ -313,13 +312,12 @@ class SubClientBibsCatalog(Client):
         url += '/holdings'
         if holding_id:
             url += ('/' + str(holding_id))
-        object_type = 'holding'
 
         args = q_params.copy()
         args['apikey'] = self.cnxn_params['api_key']
         args['format'] = 'xml'
 
-        response = self.update(url, body, args, object_type, raw=raw)
+        response = self.update(url, body, args, raw=raw)
 
         return response
 
@@ -327,7 +325,7 @@ class SubClientBibsCatalog(Client):
         """Update an Item record
 
         Args:
-            data (xml/str): This method takes a Item object.
+            body (xml/str): This method takes a Item object.
                 Note: JSON is not supported for this API.
             bib_id (str): The bib ID (mms_id).
             holding_id (str): The Holding Record ID (holding_id).
@@ -336,7 +334,7 @@ class SubClientBibsCatalog(Client):
             raw (bool): If true, returns raw requests object.
 
         Returns:
-            Item object created.
+            Item object updated.
 
         """
         url = self.cnxn_params['api_uri_full']
@@ -344,13 +342,12 @@ class SubClientBibsCatalog(Client):
         url += ('/holdings/' + str(holding_id)) + '/items'
         if item_id:
             url += ('/' + str(item_id))
-        object_type = 'item'
 
         args = q_params.copy()
         args['apikey'] = self.cnxn_params['api_key']
         args['format'] = 'xml'
 
-        response = self.update(url, body, args, object_type, raw=raw)
+        response = self.update(url, body, args, raw=raw)
 
         return response
 

--- a/almapipy/bibs.py
+++ b/almapipy/bibs.py
@@ -293,7 +293,7 @@ class SubClientBibsCatalog(Client):
 
         return response
 
-    def put_holdings(self, bib_id, holding_id, body, q_params={}, raw=True):
+    def put_holdings(self, bib_id, holding_id, body, q_params={}, raw=False):
         """Update a Holding record
 
         Args:
@@ -323,7 +323,7 @@ class SubClientBibsCatalog(Client):
 
         return response
 
-    def put_item(self, bib_id, holding_id, item_id, body, q_params={}, raw=True):
+    def put_item(self, bib_id, holding_id, item_id, body, q_params={}, raw=False):
         """Update an Item record
 
         Args:

--- a/almapipy/bibs.py
+++ b/almapipy/bibs.py
@@ -287,8 +287,9 @@ class SubClientBibsCatalog(Client):
             args['normalization'] = normalization
         if validate:
             args['validate'] = validate
-
-        response = self.update(url, body, args, object_type, raw=raw)
+            
+        cleanxml = self.clean_xml(body)
+        response = self.update(url, cleanxml, args, object_type, raw=raw)
 
         return response
 

--- a/almapipy/bibs.py
+++ b/almapipy/bibs.py
@@ -287,7 +287,7 @@ class SubClientBibsCatalog(Client):
             args['normalization'] = normalization
         if validate:
             args['validate'] = validate
-            
+
         cleanxml = self.clean_xml(body)
         response = self.update(url, cleanxml, args, object_type, raw=raw)
 

--- a/almapipy/client.py
+++ b/almapipy/client.py
@@ -8,6 +8,8 @@ import xml.etree.ElementTree as ET
 
 import requests
 
+import re
+
 from . import utils
 
 
@@ -19,6 +21,20 @@ class Client(object):
     def __init__(self, cnxn_params={}):
         # instantiate dictionary for storing alma api connection parameters
         self.cnxn_params = cnxn_params
+    
+    def clean_xml(self, xml_string):
+        # Remove invalid characters
+        xml_string = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F]', '', xml_string)
+        xml_string = re.sub(r'[^\x00-\x7F]+', '', xml_string)
+        # Ensure proper XML formatting
+        try:
+            root = ET.fromstring(xml_string)
+            return ET.tostring(root, encoding='unicode')
+        except ET.ParseError:
+            # Handle malformed XML by fixing common issues
+            xml_string = xml_string.replace('><', '>\n<')
+            xml_string = re.sub(r'<([^>]+?)\/>', r'<\1></\1>', xml_string)
+            return xml_string
 
     def create(self, url, data, args, object_type, raw=False):
         """

--- a/almapipy/client.py
+++ b/almapipy/client.py
@@ -4,7 +4,6 @@ Common Client for interacting with Alma API
 from __future__ import annotations
 
 import json
-import re
 import xml.etree.ElementTree as ET
 
 import requests
@@ -20,20 +19,6 @@ class Client(object):
     def __init__(self, cnxn_params={}):
         # instantiate dictionary for storing alma api connection parameters
         self.cnxn_params = cnxn_params
-
-    def clean_xml(self, xml_string):
-        # Remove invalid characters
-        xml_string = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F]', '', xml_string)
-        xml_string = re.sub(r'[^\x00-\x7F]+', '', xml_string)
-        # Ensure proper XML formatting
-        try:
-            root = ET.fromstring(xml_string)
-            return ET.tostring(root, encoding='unicode')
-        except ET.ParseError:
-            # Handle malformed XML by fixing common issues
-            xml_string = xml_string.replace('><', '>\n<')
-            xml_string = re.sub(r'<([^>]+?)\/>', r'<\1></\1>', xml_string)
-            return xml_string
 
     def create(self, url, data, args, object_type, raw=False):
         """
@@ -120,15 +105,15 @@ class Client(object):
 
         return content
 
-    def update(self, url, data, args, object_type, raw=False):
+    def update(self, url, data, args, raw=False):
         """
         Uses requests library to make Exlibris API Put call.
         Returns data of type specified during init of base class.
 
         Args:
             url (str): Exlibris API endpoint url.
+            data (dict): Data to be updated.
             args (dict): Query string parameters for API call.
-            object_type (str): Type of object to be posted (see alma docs)
             raw (bool): If true, returns raw response.
 
         Returns:

--- a/almapipy/client.py
+++ b/almapipy/client.py
@@ -105,6 +105,60 @@ class Client(object):
 
         return content
 
+    def update(self, url, data, args, object_type, raw=False):
+        """
+        Uses requests library to make Exlibris API Put call.
+        Returns data of type specified during init of base class.
+
+        Args:
+            url (str): Exlibris API endpoint url.
+            args (dict): Query string parameters for API call.
+            object_type (str): Type of object to be posted (see alma docs)
+            raw (bool): If true, returns raw response.
+
+        Returns:
+            JSON-esque, xml, or raw response.
+        """
+
+        # handle data format. Allow for overriding of global setting.
+        headers = {}
+        if 'format' not in args.keys():
+            if type(data) == ET or type(data) == ET.Element:
+                content_type = 'xml'
+            elif type(data) == dict:
+                content_type = 'json'
+            else:
+                content_type = self.cnxn_params['format']
+            args['format'] = self.cnxn_params['format']
+        else:
+            content_type = args['format']
+
+        # Declare data type in header, convert to string if necessary.
+        if content_type == 'json':
+            headers['content-type'] = 'application/json'
+            if type(data) != str:
+                data = json.dumps(data)
+        elif content_type == 'xml':
+            headers['content-type'] = 'application/xml'
+            if type(data) == ET or type(data) == ET.Element:
+                data = ET.tostring(data, encoding='unicode')
+            elif type(data) != str:
+                message = 'XML payload must be either string or ElementTree.'
+                raise utils.ArgError(message)
+        else:
+            message = "Put content type must be either 'json' or 'xml'"
+            raise utils.ArgError(message)
+
+        # Send request and parse response.
+        response = requests.put(url, data=data, params=args, headers=headers)
+        if raw:
+            return response
+
+        # Parse content
+        content = self.__parse_response__(response)
+
+        return content
+
     def __format_query__(self, query):
         """Converts dictionary of brief search query to a formated string.
         https://developers.exlibrisgroup.com/blog/How-we-re-building-APIs-at-Ex-Libris#BriefSearch

--- a/almapipy/client.py
+++ b/almapipy/client.py
@@ -4,11 +4,10 @@ Common Client for interacting with Alma API
 from __future__ import annotations
 
 import json
+import re
 import xml.etree.ElementTree as ET
 
 import requests
-
-import re
 
 from . import utils
 
@@ -21,7 +20,7 @@ class Client(object):
     def __init__(self, cnxn_params={}):
         # instantiate dictionary for storing alma api connection parameters
         self.cnxn_params = cnxn_params
-    
+
     def clean_xml(self, xml_string):
         # Remove invalid characters
         xml_string = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F]', '', xml_string)

--- a/almapipy/utils.py
+++ b/almapipy/utils.py
@@ -3,6 +3,8 @@ Error classes and other helpful functions
 """
 from __future__ import annotations
 
+import re
+import xml.etree.ElementTree as ET
 
 class Error(Exception):
     """Base class for exceptions"""
@@ -25,3 +27,18 @@ class ArgError(Error):
     def __init__(self, message):
         super(ArgError, self).__init__(message)
         self.message = 'Invalid Argument: ' + message
+
+class Formatter():
+    def clean_xml(xml_string):
+        # Remove invalid characters
+        xml_string = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F]', '', xml_string)
+        xml_string = re.sub(r'[^\x00-\x7F]+', '', xml_string)
+        # Ensure proper XML formatting
+        try:
+            root = ET.fromstring(xml_string)
+            return ET.tostring(root, encoding='unicode')
+        except ET.ParseError:
+            # Handle malformed XML by fixing common issues
+            xml_string = xml_string.replace('><', '>\n<')
+            xml_string = re.sub(r'<([^>]+?)\/>', r'<\1></\1>', xml_string)
+            return xml_string


### PR DESCRIPTION
Updated the python library to allow `PUT` requests to Alma for bibliographic, holdings, and item records.  I tried to follow the original developer's nomenclature and descriptive structure.

I ran into issues with the XML structure for Bibliographic Records being returned by almapipy and added the `clean_xml` function to mediate this issue.

The following records can be used for testing within our Alma Sandbox Environment:
> MMS Id: `9933212933402401`
> Holdings Id: `22144944760002401`
> Item Id: `23144944750002401`

